### PR TITLE
No universal object crates classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,25 @@
 # phpstan-stripe
 Stripe SDK extension for PHPStan
 
-Adds support for `Stripe\StripeObject` used by the PHP library for the Stripe API and also for properties used only when the object is updated.
+Adds particular types replacing `Stripe\StripeObject` type declaration for many properties in many classes used by the PHP library for the Stripe API.
+See `extension.neon` for the full list of currently replaced properties.
 
-- `Customer::$source`, [used only for `save()`](https://stripe.com/docs/api/customers/update#update_customer-source)
-- `Subscription::$coupon`, [used only for `save()`](https://stripe.com/docs/api/subscriptions/update#update_subscription-coupon)
-- `Source::$card`, [additional hash for a payment method](https://stripe.com/docs/api/sources/object#source_object-type)
-
-These are not documented using `@property` tags on the classes (or the types are wrong), and the dev team [feels](https://github.com/stripe/stripe-php/pull/543) it should stay this way. Honestly, I'm not sure adding `@property` tags would be the best way either.
+Also adds types for properties used only when the object is updated.
+These are not documented using `@property` tags on the classes (or the types are wrong), and the dev team [feels](https://github.com/stripe/stripe-php/pull/543) it should stay this way.
+Honestly, I'm not sure adding `@property` tags would be the best way either.
 
 PHPStan will obviously flag such property access and this extension will resolve those errors by telling PHPStan such properties exist.
+
+This extension is not using
+```
+parameters:
+	universalObjectCratesClasses:
+		- Stripe\StripeObject
+```
+in its configuration because in the SDK, everything `extends StripeObject` (or everything `extends ApiResource` which in turn `extends StripeObject`) so each property your code would read or write would exist, at least for PHPStan.
+And I wanted this extension to provide some more precise checks.
+
+If you don't want to or can't use this extension, add the `universalObjectCratesClasses` config snippet to your `phpstan.neon` and be ready to go.
 
 ## Installation
 
@@ -25,5 +35,5 @@ For manual installation, add this to your `phpstan.neon`:
 
 ```
 includes:
-    - vendor/spaze/phpstan-stripe/extension.neon
+	- vendor/spaze/phpstan-stripe/extension.neon
 ```

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
 		"phpstan/phpstan": "^0.12",
 		"php-parallel-lint/php-parallel-lint": "^1.2",
 		"php-parallel-lint/php-console-highlighter": "^0.5.0",
-		"spaze/coding-standard": "^0.0.4",
+		"spaze/coding-standard": "^0.0",
 		"stripe/stripe-php": "^7.0"
 	},
 	"scripts": {

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
 		"phpstan/phpstan": "^0.12",
 		"php-parallel-lint/php-parallel-lint": "^1.2",
 		"php-parallel-lint/php-console-highlighter": "^0.5.0",
-		"spaze/coding-standard": "^0.0.4"
+		"spaze/coding-standard": "^0.0.4",
+		"stripe/stripe-php": "^7.0"
 	},
 	"scripts": {
 		"lint": "vendor/bin/parallel-lint --colors src/",

--- a/extension.neon
+++ b/extension.neon
@@ -1,14 +1,30 @@
 parameters:
 	universalObjectCratesClasses:
-		- Stripe\StripeObject
+		- Spaze\PHPStan\Stripe\Retrofit\Metadata
 
 services:
 	-
-		class: Spaze\PHPStan\Reflection\Stripe\RequestProperty
+		class: Spaze\PHPStan\Stripe\StripeClassReflectionExtension
 		tags:
 			- phpstan.broker.propertiesClassReflectionExtension
 		arguments:
 			properties:
-				'Stripe\Subscription::$coupon': string
+				'Stripe\Customer::$address': Spaze\PHPStan\Stripe\Retrofit\Address|array|null
+				'Stripe\Customer::$metadata': Spaze\PHPStan\Stripe\Retrofit\Metadata
 				'Stripe\Customer::$source': string
-				'Stripe\Source::$card': Stripe\Card::class
+				'Stripe\Event::$data': Spaze\PHPStan\Stripe\Retrofit\EventData
+				'Stripe\Invoice::$customer_address': Spaze\PHPStan\Stripe\Retrofit\Address|null
+				'Stripe\Invoice::$metadata': Spaze\PHPStan\Stripe\Retrofit\Metadata
+				'Stripe\Invoice::$tax_percent': float|null  # deprecated & removed from objects in API https://stripe.com/docs/upgrades#2020-08-27
+				'Stripe\InvoiceLineItem::$discount_amounts': array
+				'Stripe\InvoiceLineItem::$metadata': Spaze\PHPStan\Stripe\Retrofit\Metadata
+				'Stripe\InvoiceLineItem::$period': Spaze\PHPStan\Stripe\Retrofit\Period
+				'Stripe\Source::$card': Stripe\Card
+				'Stripe\Source::$metadata': Spaze\PHPStan\Stripe\Retrofit\Metadata
+				'Stripe\Source::$owner': Spaze\PHPStan\Stripe\Retrofit\SourceOwner
+				'Stripe\Source::$redirect': Spaze\PHPStan\Stripe\Retrofit\Redirect
+				'Stripe\Source::$three_d_secure': Spaze\PHPStan\Stripe\Retrofit\ThreeDSecure
+				'Stripe\Subscription::$coupon': string
+				'Stripe\Subscription::$items': Spaze\PHPStan\Stripe\Retrofit\SubscriptionItems
+				'Stripe\Subscription::$metadata': Spaze\PHPStan\Stripe\Retrofit\Metadata
+				'Stripe\Subscription::$plan': Stripe\Plan

--- a/src/Retrofit/Address.php
+++ b/src/Retrofit/Address.php
@@ -1,0 +1,16 @@
+<?php
+declare(strict_types = 1);
+
+namespace Spaze\PHPStan\Stripe\Retrofit;
+
+/**
+ * @property string $city
+ * @property string $country
+ * @property string $line1
+ * @property string $line2
+ * @property string $postal_code
+ * @property string $state
+ */
+class Address
+{
+}

--- a/src/Retrofit/EventData.php
+++ b/src/Retrofit/EventData.php
@@ -1,0 +1,13 @@
+<?php
+declare(strict_types = 1);
+
+namespace Spaze\PHPStan\Stripe\Retrofit;
+
+use Stripe\StripeObject;
+
+/**
+ * @property StripeObject $object
+ */
+class EventData extends StripeObject
+{
+}

--- a/src/Retrofit/Metadata.php
+++ b/src/Retrofit/Metadata.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types = 1);
+
+namespace Spaze\PHPStan\Stripe\Retrofit;
+
+/**
+ * @method string __get(string $name)
+ * @method void __set(string $name, string $value)
+ */
+class Metadata
+{
+}

--- a/src/Retrofit/Period.php
+++ b/src/Retrofit/Period.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types = 1);
+
+namespace Spaze\PHPStan\Stripe\Retrofit;
+
+/**
+ * @property int $start
+ * @property int $end
+ */
+class Period
+{
+}

--- a/src/Retrofit/Redirect.php
+++ b/src/Retrofit/Redirect.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types = 1);
+
+namespace Spaze\PHPStan\Stripe\Retrofit;
+
+/**
+ * @property string $failure_reason
+ * @property string $return_url
+ * @property string $status
+ * @property string $url
+ */
+class Redirect
+{
+}

--- a/src/Retrofit/SourceOwner.php
+++ b/src/Retrofit/SourceOwner.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types = 1);
+
+namespace Spaze\PHPStan\Stripe\Retrofit;
+
+/**
+ * @property Address|null $address
+ * @property string $email
+ * @property string $name
+ * @property string $phone
+ * @property Address|null $verified_address
+ * @property string $verified_email
+ * @property string $verified_name
+ * @property string $verified_phone
+ */
+class SourceOwner
+{
+}

--- a/src/Retrofit/SubscriptionItems.php
+++ b/src/Retrofit/SubscriptionItems.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types = 1);
+
+namespace Spaze\PHPStan\Stripe\Retrofit;
+
+use Stripe\Collection;
+use Stripe\SubscriptionItem;
+
+/**
+ * @property array<int, SubscriptionItem> $data
+ */
+class SubscriptionItems extends Collection
+{
+}

--- a/src/Retrofit/ThreeDSecure.php
+++ b/src/Retrofit/ThreeDSecure.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types = 1);
+
+namespace Spaze\PHPStan\Stripe\Retrofit;
+
+/**
+ * @property string $customer
+ */
+class ThreeDSecure
+{
+}

--- a/src/StripePropertyReflection.php
+++ b/src/StripePropertyReflection.php
@@ -1,0 +1,105 @@
+<?php
+declare(strict_types = 1);
+
+namespace Spaze\PHPStan\Stripe;
+
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\PropertyReflection;
+use PHPStan\TrinaryLogic;
+use PHPStan\Type\Type;
+
+class StripePropertyReflection implements PropertyReflection
+{
+
+	/** @var ClassReflection */
+	private $declaringClass;
+
+	/** @var Type */
+	private $type;
+
+
+	public function __construct(ClassReflection $declaringClass, Type $type)
+	{
+		$this->declaringClass = $declaringClass;
+		$this->type = $type;
+	}
+
+
+	public function getDeclaringClass(): ClassReflection
+	{
+		return $this->declaringClass;
+	}
+
+
+	public function isStatic(): bool
+	{
+		return false;
+	}
+
+
+	public function isPrivate(): bool
+	{
+		return false;
+	}
+
+
+	public function isPublic(): bool
+	{
+		return true;
+	}
+
+
+	public function getDocComment(): ?string
+	{
+		return null;
+	}
+
+
+	public function getReadableType(): Type
+	{
+		return $this->type;
+	}
+
+
+	public function getWritableType(): Type
+	{
+		return $this->type;
+	}
+
+
+	public function canChangeTypeAfterAssignment(): bool
+	{
+		return true;
+	}
+
+
+	public function isReadable(): bool
+	{
+		return true;
+	}
+
+
+	public function isWritable(): bool
+	{
+		return true;
+	}
+
+
+	public function isDeprecated(): TrinaryLogic
+	{
+		return TrinaryLogic::createNo();
+	}
+
+
+	public function getDeprecatedDescription(): ?string
+	{
+		return null;
+	}
+
+
+	public function isInternal(): TrinaryLogic
+	{
+		return TrinaryLogic::createNo();
+	}
+
+}


### PR DESCRIPTION
Rewrite to not use `universalObjectCratesClasses` config option.

That option is the sole thing that's needed for PHPStan to work without throwing any errors, so all other options were superfluous. But with that option, all properties were treated by PHPStan as existing because everything in the SDK `extends StripeObject` either directly or through `ApiResource`.

I wanted (more) precise checks.