### PR TITLE
`Stripe\AlipayAccount` is deprecated and doesn't have properties declared

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -10,6 +10,7 @@ services:
 		arguments:
 			properties:
 				'Stripe\Customer::$address': Spaze\PHPStan\Stripe\Retrofit\Address|array|null
+				'Stripe\Customer::$default_source': null|string|\Stripe\Account|\Stripe\BankAccount|\Stripe\BitcoinReceiver|\Stripe\Card|\Stripe\Source
 				'Stripe\Customer::$metadata': Spaze\PHPStan\Stripe\Retrofit\Metadata
 				'Stripe\Customer::$source': string
 				'Stripe\Event::$data': Spaze\PHPStan\Stripe\Retrofit\EventData


### PR DESCRIPTION
So let's "undeclare" it for `Customer::$default_source` too.