### PR TITLE
Require PHPStan 1.0, PHP 7.3

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -10,8 +10,6 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - 7.1
-          - 7.2
           - 7.3
           - 7.4
           - 8.0

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
 		}
 	},
 	"require": {
-		"php": "^7.1 || ^8.0",
+		"php": "^7.3 || ^8.0",
 		"phpstan/phpstan": "^1.0"
 	},
 	"require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -18,10 +18,11 @@
 		}
 	},
 	"require": {
-		"php": "^7.1 || ^8.0"
+		"php": "^7.1 || ^8.0",
+		"phpstan/phpstan": "^1.0"
 	},
 	"require-dev": {
-		"phpstan/phpstan": "^0.12",
+		"nikic/php-parser": "^4.13",
 		"php-parallel-lint/php-parallel-lint": "^1.2",
 		"php-parallel-lint/php-console-highlighter": "^0.5.0",
 		"spaze/coding-standard": "^0.0",

--- a/extension.neon
+++ b/extension.neon
@@ -9,6 +9,7 @@ services:
 			- phpstan.broker.propertiesClassReflectionExtension
 		arguments:
 			properties:
+				'Stripe\Coupon::$metadata': Spaze\PHPStan\Stripe\Retrofit\Metadata
 				'Stripe\Customer::$address': Spaze\PHPStan\Stripe\Retrofit\Address|array|null
 				'Stripe\Customer::$default_source': null|string|\Stripe\Account|\Stripe\BankAccount|\Stripe\BitcoinReceiver|\Stripe\Card|\Stripe\Source
 				'Stripe\Customer::$metadata': Spaze\PHPStan\Stripe\Retrofit\Metadata

--- a/src/StripeClassReflectionExtension.php
+++ b/src/StripeClassReflectionExtension.php
@@ -76,7 +76,7 @@ class StripeClassReflectionExtension implements PropertiesClassReflectionExtensi
 						// `array` or `array<itemType>` or `array<keyType, itemType>`
 						$type = new ArrayType(
 							isset($matches[2]) ? $this->getTypeFromString($matches[1]) : (isset($matches[1]) ? new IntegerType() : new MixedType()),
-							$matches[2] ?? $matches[1] ?? new MixedType()
+							$matches[2] ?? $matches[1] ?? new MixedType(),
 						);
 					} else {
 						$type = new ObjectType($part);


### PR DESCRIPTION
- Require PHPStan 1.0
- Require PHP 7.3, mostly because coding standard requires trailing commas
- Add `Coupon::$metadata`