### PR TITLE
Add pseudo-type for values of the `Stripe\Invoice::$total_tax_amounts` array

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -19,6 +19,7 @@ services:
 				'Stripe\Invoice::$customer_address': Spaze\PHPStan\Stripe\Retrofit\Address|null
 				'Stripe\Invoice::$metadata': Spaze\PHPStan\Stripe\Retrofit\Metadata
 				'Stripe\Invoice::$tax_percent': float|null  # deprecated & removed from objects in API https://stripe.com/docs/upgrades#2020-08-27
+				'Stripe\Invoice::$total_tax_amounts': 'array<int, Spaze\PHPStan\Stripe\Retrofit\TotalTaxAmount>'
 				'Stripe\InvoiceLineItem::$discount_amounts': array
 				'Stripe\InvoiceLineItem::$metadata': Spaze\PHPStan\Stripe\Retrofit\Metadata
 				'Stripe\InvoiceLineItem::$period': Spaze\PHPStan\Stripe\Retrofit\Period

--- a/src/Retrofit/TotalTaxAmount.php
+++ b/src/Retrofit/TotalTaxAmount.php
@@ -1,0 +1,15 @@
+<?php
+declare(strict_types = 1);
+
+namespace Spaze\PHPStan\Stripe\Retrofit;
+
+use Stripe\TaxRate;
+
+/**
+ * @property int $amount
+ * @property bool $inclusive
+ * @property string|TaxRate $tax_rate
+ */
+class TotalTaxAmount
+{
+}


### PR DESCRIPTION
Currently [documented as](https://github.com/stripe/stripe-php/blob/5a55767326e77dac8a0f57022d27533beeafc197/lib/Invoice.php#L117)
```
 * @property \Stripe\StripeObject[] $total_tax_amounts The aggregate amounts calculated per tax rate for all line items.
```
which is not enough for a proper static analysis.