### PR TITLE
PHP 8.2 Deprecated Dynamic Properties

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -10,8 +10,6 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "7.3"
-          - "7.4"
           - "8.0"
           - "8.1"
           - "8.2"

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
 		}
 	},
 	"require": {
-		"php": "^7.3 || ^8.0",
+		"php": "^8.0",
 		"phpstan/phpstan": "^1.7"
 	},
 	"require-dev": {

--- a/src/Retrofit/Address.php
+++ b/src/Retrofit/Address.php
@@ -3,14 +3,12 @@ declare(strict_types = 1);
 
 namespace Spaze\PHPStan\Stripe\Retrofit;
 
-/**
- * @property string $city
- * @property string $country
- * @property string $line1
- * @property string $line2
- * @property string $postal_code
- * @property string $state
- */
 class Address
 {
+	public string $city;
+	public string $country;
+	public string $line1;
+	public string $line2;
+	public string $postal_code;
+	public string $state;
 }

--- a/src/Retrofit/CustomerInvoiceSettings.php
+++ b/src/Retrofit/CustomerInvoiceSettings.php
@@ -3,12 +3,13 @@ declare(strict_types = 1);
 
 namespace Spaze\PHPStan\Stripe\Retrofit;
 
-/**
- * @property StripeObject $custom_fields
- * @property string|\Stripe\PaymentMethod $default_payment_method
- * @property string $footer
- * @property StripeObject $rendering_options
- */
+use Stripe\PaymentMethod;
+use Stripe\StripeObject;
+
 class CustomerInvoiceSettings
 {
+	public StripeObject $custom_fields;
+	public string|PaymentMethod $default_payment_method;
+	public string $footer;
+	public StripeObject $rendering_options;
 }

--- a/src/Retrofit/EventData.php
+++ b/src/Retrofit/EventData.php
@@ -5,10 +5,8 @@ namespace Spaze\PHPStan\Stripe\Retrofit;
 
 use Stripe\StripeObject;
 
-/**
- * @property StripeObject $object
- * @property StripeObject $previous_attributes
- */
 class EventData extends StripeObject
 {
+	public StripeObject $object;
+	public StripeObject $previous_attributes;
 }

--- a/src/Retrofit/PaymentIntentNextAction.php
+++ b/src/Retrofit/PaymentIntentNextAction.php
@@ -3,10 +3,14 @@ declare(strict_types = 1);
 
 namespace Spaze\PHPStan\Stripe\Retrofit;
 
-/**
- * @property StripeObject $redirect_to_url
- * @property 'redirect_to_url'|'use_stripe_sdk'|'alipay_handle_redirect'|'oxxo_display_details'|'verify_with_microdeposits' $type
- */
+use Stripe\StripeObject;
+
 class PaymentIntentNextAction
 {
+	public StripeObject $redirect_to_url;
+
+	/**
+	 * @var 'redirect_to_url'|'use_stripe_sdk'|'alipay_handle_redirect'|'oxxo_display_details'|'verify_with_microdeposits'
+	 */
+	public string $type;
 }

--- a/src/Retrofit/PaymentMethodCard.php
+++ b/src/Retrofit/PaymentMethodCard.php
@@ -3,18 +3,22 @@ declare(strict_types = 1);
 
 namespace Spaze\PHPStan\Stripe\Retrofit;
 
-/**
- * @property 'amex'|'diners'|'discover'|'jcb'|'mastercard'|'unionpay'|'visa'|'unknown' $brand
- * @property StripeObject $checks
- * @property string $country
- * @property int $exp_month
- * @property int $exp_year
- * @property string $fingerprint
- * @property string $funding
- * @property StripeObject $generated_from
- * @property StripeObject $three_d_secure_usage
- * @property StripeObject $wallet
- */
+use Stripe\StripeObject;
+
+// https://stripe.com/docs/api/payment_methods/object#payment_method_object-card
 class PaymentMethodCard
 {
+	/*
+	 * @var 'amex'|'diners'|'discover'|'jcb'|'mastercard'|'unionpay'|'visa'|'unknown'
+	 */
+	public string $brand;
+	public StripeObject $checks;
+	public int $exp_month;
+	public int $exp_year;
+	public string $fingerprint;
+	public string $funding;
+	public StripeObject $generated_from;
+	public string $last4;
+	public StripeObject $three_d_secure_usage;
+	public StripeObject $wallet;
 }

--- a/src/Retrofit/Period.php
+++ b/src/Retrofit/Period.php
@@ -3,10 +3,8 @@ declare(strict_types = 1);
 
 namespace Spaze\PHPStan\Stripe\Retrofit;
 
-/**
- * @property int $start
- * @property int $end
- */
 class Period
 {
+	public int $start;
+	public int $end;
 }

--- a/src/Retrofit/Redirect.php
+++ b/src/Retrofit/Redirect.php
@@ -3,12 +3,10 @@ declare(strict_types = 1);
 
 namespace Spaze\PHPStan\Stripe\Retrofit;
 
-/**
- * @property string $failure_reason
- * @property string $return_url
- * @property string $status
- * @property string $url
- */
 class Redirect
 {
+	public string $failure_reason;
+	public string $return_url;
+	public string $status;
+	public string $url;
 }

--- a/src/Retrofit/SourceOwner.php
+++ b/src/Retrofit/SourceOwner.php
@@ -3,16 +3,14 @@ declare(strict_types = 1);
 
 namespace Spaze\PHPStan\Stripe\Retrofit;
 
-/**
- * @property Address|null $address
- * @property string $email
- * @property string $name
- * @property string $phone
- * @property Address|null $verified_address
- * @property string $verified_email
- * @property string $verified_name
- * @property string $verified_phone
- */
 class SourceOwner
 {
+	public Address|null $address;
+	public string $email;
+	public string $name;
+	public string $phone;
+	public Address|null $verified_address;
+	public string $verified_email;
+	public string $verified_name;
+	public string $verified_phone;
 }

--- a/src/Retrofit/SubscriptionItems.php
+++ b/src/Retrofit/SubscriptionItems.php
@@ -10,8 +10,11 @@ use Stripe\SubscriptionItem;
 /**
  * @template TStripeObject of StripeObject
  * @template-extends Collection<TStripeObject>
- * @property array<int, SubscriptionItem> $data
  */
 class SubscriptionItems extends Collection
 {
+	/**
+	 * @var array<int, SubscriptionItem>
+	 */
+	public array $data;
 }

--- a/src/Retrofit/ThreeDSecure.php
+++ b/src/Retrofit/ThreeDSecure.php
@@ -3,9 +3,7 @@ declare(strict_types = 1);
 
 namespace Spaze\PHPStan\Stripe\Retrofit;
 
-/**
- * @property string $customer
- */
 class ThreeDSecure
 {
+	public string $customer;
 }

--- a/src/Retrofit/TotalTaxAmount.php
+++ b/src/Retrofit/TotalTaxAmount.php
@@ -5,11 +5,9 @@ namespace Spaze\PHPStan\Stripe\Retrofit;
 
 use Stripe\TaxRate;
 
-/**
- * @property int $amount
- * @property bool $inclusive
- * @property string|TaxRate $tax_rate
- */
 class TotalTaxAmount
 {
+	public int $amount;
+	public bool $inclusive;
+	public string|TaxRate $tax_rate;
 }


### PR DESCRIPTION
Use real properties in the stubs, drop support for PHP 7 because some type hints require union types. Given PHP 7 is EOL, this seems reasonable.