### PR TITLE
Support also stripe-php 9.x and 10.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
 		"php-parallel-lint/php-parallel-lint": "^1.2",
 		"php-parallel-lint/php-console-highlighter": "^1.0",
 		"spaze/coding-standard": "^1.1",
-		"stripe/stripe-php": "^8.7"
+		"stripe/stripe-php": "^8.7|^9.9|^10.8"
 	},
 	"scripts": {
 		"lint": "vendor/bin/parallel-lint --colors src/",


### PR DESCRIPTION
Using always the latest available versions for the version number.