### PR TITLE
Add BalanceItem for Stripe\Balance

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -9,6 +9,9 @@ services:
 			- phpstan.broker.propertiesClassReflectionExtension
 		arguments:
 			properties:
+				'Stripe\Balance::$available': 'array<int, Spaze\PHPStan\Stripe\Retrofit\BalanceItem>'
+				'Stripe\Balance::$pending': 'array<int, Spaze\PHPStan\Stripe\Retrofit\BalanceItem>'
+				'Stripe\Balance::$connect_reserved': 'array<int, Spaze\PHPStan\Stripe\Retrofit\BalanceItem>'
 				'Stripe\Charge::$metadata': Spaze\PHPStan\Stripe\Retrofit\Metadata
 				'Stripe\Coupon::$metadata': Spaze\PHPStan\Stripe\Retrofit\Metadata
 				'Stripe\Customer::$address': Spaze\PHPStan\Stripe\Retrofit\Address|array|null

--- a/src/Retrofit/BalanceItem.php
+++ b/src/Retrofit/BalanceItem.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types = 1);
+
+namespace Spaze\PHPStan\Stripe\Retrofit;
+
+class BalanceItem
+{
+	public int $amount;
+
+	public string $currency;
+
+	/** @var null|array<BalanceItemSourceType> */
+	public ?array $source_types;
+}

--- a/src/Retrofit/BalanceItemSourceType.php
+++ b/src/Retrofit/BalanceItemSourceType.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types = 1);
+
+namespace Spaze\PHPStan\Stripe\Retrofit;
+
+class BalanceItemSourceType
+{
+	public int $bank_account;
+	public int $card;
+	public int $fpx;
+}


### PR DESCRIPTION
https://stripe.com/docs/api/balance/balance_object

This Stripe object have several StripeObject in their arrays which has specific properties not defined like $amount or $currency

Just add a new type called `BalanceItem` (I accept suggestions with the name) defining their children attributes