### PR TITLE
Adding support for Bank Account payment methods.

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -29,6 +29,7 @@ services:
 				'Stripe\InvoiceLineItem::$period': Spaze\PHPStan\Stripe\Retrofit\Period
 				'Stripe\PaymentIntent::$next_action': Spaze\PHPStan\Stripe\Retrofit\PaymentIntentNextAction|null
 				'Stripe\PaymentMethod::$card': Spaze\PHPStan\Stripe\Retrofit\PaymentMethodCard|null
+				'Stripe\PaymentMethod::$us_bank_account': Spaze\PHPStan\Stripe\Retrofit\PaymentMethodBank|null
 				'Stripe\Source::$card': Stripe\Card
 				'Stripe\Source::$metadata': Spaze\PHPStan\Stripe\Retrofit\Metadata
 				'Stripe\Source::$owner': Spaze\PHPStan\Stripe\Retrofit\SourceOwner|null

--- a/src/Retrofit/PaymentMethodBank.php
+++ b/src/Retrofit/PaymentMethodBank.php
@@ -1,0 +1,35 @@
+<?php
+declare(strict_types = 1);
+
+namespace Spaze\PHPStan\Stripe\Retrofit;
+
+// Documentation on Bank objects in Payment Method can be found at:
+// https://docs.stripe.com/api/payment_methods/object#payment_method_object-us_bank_account
+
+// Additional documentation here for a separate endpoint, but useful reference:
+// https://docs.stripe.com/api/customer_bank_accounts/object
+
+class PaymentMethodBank
+{
+	// Simple types:
+
+	public ?string $bank_name;
+	public ?string $financial_connections_account;
+	public ?string $fingerprint;
+	public ?string $last4;
+	public ?string $routing_number;
+
+	// Deeper StripeObjects:
+
+	public ?PaymentMethodBank\Networks $networks;
+	public ?PaymentMethodBank\StatusDetails $status_details;
+
+	// Enum values:
+
+	/** @var 'company'|'individual'|null */
+	public ?string $account_holder_type;
+
+	/** @var 'checking'|'savings'|null */
+	public ?string $account_type;
+
+}

--- a/src/Retrofit/PaymentMethodBank/Blocked.php
+++ b/src/Retrofit/PaymentMethodBank/Blocked.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types = 1);
+
+namespace Spaze\PHPStan\Stripe\Retrofit\PaymentMethodBank;
+
+/** @see Spaze\PHPStan\Stripe\Retrofit\PaymentMethodBank */
+class Blocked
+{
+	/**
+	 * @var 'R02'|'R03'|'R04'|'R05'|'R07'|'R08'|'R10'|'R11'|'R16'|'R20'|'R29'|'R31'|null
+	 */
+	public ?string $network_code;
+
+	/**
+	 * @var 'bank_account_closed'|'bank_account_frozen'|'bank_account_invalid_details'|'bank_account_restricted'|'bank_account_unusable'|'debit_not_authorized'|null
+	 */
+	public ?string $reason;
+}

--- a/src/Retrofit/PaymentMethodBank/Networks.php
+++ b/src/Retrofit/PaymentMethodBank/Networks.php
@@ -1,0 +1,13 @@
+<?php
+declare(strict_types = 1);
+
+namespace Spaze\PHPStan\Stripe\Retrofit\PaymentMethodBank;
+
+/** @see Spaze\PHPStan\Stripe\Retrofit\PaymentMethodBank */
+class Networks
+{
+	public ?string $preferred;
+
+	/** @var array<'ach'|'us_domestic_wire'> */
+	public array $supported;
+}

--- a/src/Retrofit/PaymentMethodBank/StatusDetails.php
+++ b/src/Retrofit/PaymentMethodBank/StatusDetails.php
@@ -1,0 +1,10 @@
+<?php
+declare(strict_types = 1);
+
+namespace Spaze\PHPStan\Stripe\Retrofit\PaymentMethodBank;
+
+/** @see Spaze\PHPStan\Stripe\Retrofit\PaymentMethodBank */
+class StatusDetails
+{
+	public ?Blocked $blocked;
+}


### PR DESCRIPTION
In our codebase where we were using spaze/phpstan-stripe, we recently added some code to properly handle when someone's payment method was a bank account.  And then found that the extension didn't have those field modeled.

This PR adds the support for those fields, with appropriate sub-objects as well ... and in testing, solves the problems that we had causing us to otherwise ignore phpstan errors.