### PR TITLE
Composer future-proofing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
 		"php-parallel-lint/php-parallel-lint": "^1.2",
 		"php-parallel-lint/php-console-highlighter": "^1.0",
 		"spaze/coding-standard": "^1.1",
-		"stripe/stripe-php": "^8.7|^9.9|^10.8"
+		"stripe/stripe-php": "^8.7|^9.9|^10.8",
+		"phpstan/phpstan-deprecation-rules": "*"
 	},
 	"scripts": {
 		"lint": "vendor/bin/parallel-lint --colors src/",

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,6 @@
 		"phpstan/phpstan": "^1.7"
 	},
 	"require-dev": {
-		"nikic/php-parser": "^4.13",
 		"php-parallel-lint/php-parallel-lint": "^1.2",
 		"php-parallel-lint/php-console-highlighter": "^1.0",
 		"spaze/coding-standard": "^1.1",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,3 +4,4 @@ parameters:
 		- src
 
 includes:
+	- vendor/phpstan/phpstan-deprecation-rules/rules.neon


### PR DESCRIPTION
- Remove unused dev dependency
- Enable PHPStan deprecation alerts
    - No problems found at this time, but may help in the future